### PR TITLE
fix: scope allowed-tools to readonly and correct README init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ export ANTHROPIC_API_KEY='your_key'
 ### Usage Options
 
 #### Use as Plugin (Recommended)
-After installing the plugin and running `/scientific-writer:init`, simply ask Claude:
+After installing the plugin and running `/claude-scientific-writer:scientific-writer-init`, simply ask Claude:
 ```bash
 > Create a Nature paper on CRISPR gene editing. Present experimental_data.csv 
   (efficiency across 5 cell lines), include Western_blot.png and flow_cytometry.png 
@@ -120,7 +120,7 @@ asyncio.run(main())
 
 4. **Initialize in your project**:
    ```bash
-   /scientific-writer:init
+   /claude-scientific-writer:scientific-writer-init
    ```
    This creates a `CLAUDE.md` file with comprehensive scientific writing instructions and makes all 19+ skills available.
 
@@ -447,7 +447,7 @@ For developers working on the plugin or testing locally:
 
 6. **Test the plugin**:
    - Open any project directory
-   - Run `/scientific-writer:init`
+   - Run `/claude-scientific-writer:scientific-writer-init`
    - Verify CLAUDE.md is created
    - Test skills: "What skills are available?"
    - Try creating a document: "Create a short scientific abstract on quantum computing"
@@ -460,7 +460,7 @@ claude-scientific-writer/
 ├── .claude-plugin/
 │   └── plugin.json          # Plugin metadata
 ├── commands/
-│   └── scientific-writer-init.md  # /scientific-writer:init command
+│   └── scientific-writer-init.md  # /claude-scientific-writer:scientific-writer-init command
 ├── skills/                  # All 20 skills
 │   ├── citation-management/
 │   ├── clinical-decision-support/

--- a/skills/citation-management/SKILL.md
+++ b/skills/citation-management/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: citation-management
 description: Comprehensive citation management for academic research. Search Google Scholar and PubMed for papers, extract accurate metadata, validate citations, and generate properly formatted BibTeX entries. This skill should be used when you need to find papers, verify citation information, convert DOIs to BibTeX, or ensure reference accuracy in scientific writing.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Citation Management

--- a/skills/clinical-decision-support/SKILL.md
+++ b/skills/clinical-decision-support/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clinical-decision-support
 description: "Generate professional clinical decision support (CDS) documents for pharmaceutical and clinical research settings, including patient cohort analyses (biomarker-stratified with outcomes) and treatment recommendation reports (evidence-based guidelines with decision algorithms). Supports GRADE evidence grading, statistical analysis (hazard ratios, survival curves, waterfall plots), biomarker integration, and regulatory compliance. Outputs publication-ready LaTeX/PDF format optimized for drug development, clinical research, and evidence synthesis."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Clinical Decision Support Documents

--- a/skills/clinical-reports/SKILL.md
+++ b/skills/clinical-reports/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: clinical-reports
 description: "Write comprehensive clinical reports including case reports (CARE guidelines), diagnostic reports (radiology/pathology/lab), clinical trial reports (ICH-E3, SAE, CSR), and patient documentation (SOAP, H&P, discharge summaries). Full support with templates, regulatory compliance (HIPAA, FDA, ICH-GCP), and validation tools."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Clinical Report Writing

--- a/skills/hypothesis-generation/SKILL.md
+++ b/skills/hypothesis-generation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hypothesis-generation
 description: "Generate testable hypotheses. Formulate from observations, design experiments, explore competing explanations, develop predictions, propose mechanisms, for scientific inquiry across domains."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Scientific Hypothesis Generation

--- a/skills/infographics/SKILL.md
+++ b/skills/infographics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: infographics
 description: "Create professional infographics using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Integrates research-lookup and web search for accurate data. Supports 10 infographic types, 8 industry styles, and colorblind-safe palettes."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Infographics

--- a/skills/latex-posters/SKILL.md
+++ b/skills/latex-posters/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: latex-posters
 description: "Create professional research posters in LaTeX using beamerposter, tikzposter, or baposter. Support for conference presentations, academic posters, and scientific communication. Includes layout design, color schemes, multi-column formats, figure integration, and poster-specific best practices for visual communication."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # LaTeX Research Posters

--- a/skills/literature-review/SKILL.md
+++ b/skills/literature-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: literature-review
 description: Conduct comprehensive, systematic literature reviews using multiple academic databases (PubMed, arXiv, bioRxiv, Semantic Scholar, etc.). This skill should be used when conducting systematic literature reviews, meta-analyses, research synthesis, or comprehensive literature searches across biomedical, scientific, and technical domains. Creates professionally formatted markdown documents and PDFs with verified citations in multiple citation styles (APA, Nature, Vancouver, etc.).
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Literature Review

--- a/skills/market-research-reports/SKILL.md
+++ b/skills/market-research-reports/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: market-research-reports
 description: "Generate comprehensive market research reports (50+ pages) in the style of top consulting firms (McKinsey, BCG, Gartner). Features professional LaTeX formatting, extensive visual generation with scientific-schematics and generate-image, deep integration with research-lookup for data gathering, and multi-framework strategic analysis including Porter's Five Forces, PESTLE, SWOT, TAM/SAM/SOM, and BCG Matrix."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Market Research Reports

--- a/skills/markitdown/SKILL.md
+++ b/skills/markitdown/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: markitdown
 description: "Convert files and office documents to Markdown. Supports PDF, DOCX, PPTX, XLSX, images (with OCR), audio (with transcription), HTML, CSV, JSON, XML, ZIP, YouTube URLs, EPubs and more."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 license: MIT
 source: https://github.com/microsoft/markitdown
 ---

--- a/skills/paper-2-web/SKILL.md
+++ b/skills/paper-2-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: paper-2-web
 description: This skill should be used when converting academic papers into promotional and presentation formats including interactive websites (Paper2Web), presentation videos (Paper2Video), and conference posters (Paper2Poster). Use this skill for tasks involving paper dissemination, conference preparation, creating explorable academic homepages, generating video abstracts, or producing print-ready posters from LaTeX or PDF sources.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Paper2All: Academic Paper Transformation Pipeline

--- a/skills/parallel-web/SKILL.md
+++ b/skills/parallel-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: parallel-web
 description: "Search the web, extract URL content, and run deep research using the Parallel Chat API and Extract API. Use for ALL web searches, research queries, and general information gathering. Provides synthesized summaries with citations."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Parallel Web Systems API

--- a/skills/peer-review/SKILL.md
+++ b/skills/peer-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: peer-review
 description: "Systematic peer review toolkit. Evaluate methodology, statistics, design, reproducibility, ethics, figure integrity, reporting standards, for manuscript and grant review across disciplines."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Scientific Critical Evaluation and Peer Review

--- a/skills/pptx-posters/SKILL.md
+++ b/skills/pptx-posters/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: latex-posters
 description: "Create professional research posters in LaTeX using beamerposter, tikzposter, or baposter. Support for conference presentations, academic posters, and scientific communication. Includes layout design, color schemes, multi-column formats, figure integration, and poster-specific best practices for visual communication."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # LaTeX Research Posters

--- a/skills/research-grants/SKILL.md
+++ b/skills/research-grants/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-grants
 description: "Write competitive research proposals for NSF, NIH, DOE, and DARPA. Agency-specific formatting, review criteria, budget preparation, broader impacts, significance statements, innovation narratives, and compliance with submission requirements."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Research Grant Writing

--- a/skills/research-lookup/SKILL.md
+++ b/skills/research-lookup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: research-lookup
 description: "Look up current research information using the Parallel Chat API (primary) or Perplexity sonar-pro-search (academic paper searches). Automatically routes queries to the best backend. Use for finding papers, gathering research data, and verifying scientific information."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Research Information Lookup

--- a/skills/scientific-critical-thinking/SKILL.md
+++ b/skills/scientific-critical-thinking/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scientific-critical-thinking
 description: "Evaluate research rigor. Assess methodology, experimental design, statistical validity, biases, confounding, evidence quality (GRADE, Cochrane ROB), for critical analysis of scientific claims."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Scientific Critical Thinking

--- a/skills/scientific-schematics/SKILL.md
+++ b/skills/scientific-schematics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scientific-schematics
 description: "Create publication-quality scientific diagrams using Nano Banana Pro AI with smart iterative refinement. Uses Gemini 3 Pro for quality review. Only regenerates if quality is below threshold for your document type. Specialized in neural network architectures, system diagrams, flowcharts, biological pathways, and complex scientific visualizations."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Scientific Schematics and Diagrams

--- a/skills/scientific-slides/SKILL.md
+++ b/skills/scientific-slides/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scientific-slides
 description: "Build slide decks and presentations for research talks using Nano Banana Pro AI. Generates stunning PDF presentations with AI-generated slides. Use for conference presentations, seminar talks, thesis defense slides, or any scientific talk. Provides slide structure, design guidance, timing recommendations, and visual validation."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Scientific Slides

--- a/skills/scientific-writing/SKILL.md
+++ b/skills/scientific-writing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scientific-writing
 description: "Core skill for the deep research and writing tool. Write scientific manuscripts in full paragraphs (never bullet points). Use two-stage process: (1) create section outlines with key points using research-lookup, (2) convert to flowing prose. IMRAD structure, citations (APA/AMA/Vancouver), figures/tables, reporting guidelines (CONSORT/STROBE/PRISMA), for research papers and journal submissions."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Scientific Writing

--- a/skills/treatment-plans/SKILL.md
+++ b/skills/treatment-plans/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: treatment-plans
 description: "Generate concise (3-4 page), focused medical treatment plans in LaTeX/PDF format for all clinical specialties. Supports general medical treatment, rehabilitation therapy, mental health care, chronic disease management, perioperative care, and pain management. Includes SMART goal frameworks, evidence-based interventions with minimal text citations, regulatory compliance (HIPAA), and professional formatting. Prioritizes brevity and clinical actionability."
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Treatment Plan Writing

--- a/skills/venue-templates/SKILL.md
+++ b/skills/venue-templates/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: venue-templates
 description: Access comprehensive LaTeX templates, formatting requirements, and submission guidelines for major scientific publication venues (Nature, Science, PLOS, IEEE, ACM), academic conferences (NeurIPS, ICML, CVPR, CHI), research posters, and grant proposals (NSF, NIH, DOE, DARPA). This skill should be used when preparing manuscripts for journal submission, conference papers, research posters, or grant proposals and need venue-specific formatting requirements and templates.
-allowed-tools: [Read, Write, Edit, Bash]
+allowed-tools: [Read, Grep, Glob]
 ---
 
 # Venue Templates


### PR DESCRIPTION
Closes #12, closes #11

## Changes

- **Security (#12)**: reduce `allowed-tools` to `[Read, Grep, Glob]` across all 21 SKILL.md files — `Write`, `Edit`, and `Bash` were silently bypassing user permission settings
- **Docs (#11)**: fix README init command from `/scientific-writer:init` to `/claude-scientific-writer:scientific-writer-init` (3 occurrences)