### PR TITLE
docs: add Reddit to the social badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![X](https://img.shields.io/badge/Follow_on_X-%40k__dense__ai-000000?logo=x)](https://x.com/k_dense_ai)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-K--Dense_Inc.-0A66C2?logo=linkedin)](https://www.linkedin.com/company/k-dense-inc)
 [![YouTube](https://img.shields.io/badge/YouTube-K--Dense_Inc.-FF0000?logo=youtube)](https://www.youtube.com/@K-Dense-Inc)
+[![Reddit](https://img.shields.io/badge/Reddit-u%2F--k--dense---FF4500?logo=reddit&logoColor=white)](https://www.reddit.com/user/-k-dense-/)
 [![Blog](https://img.shields.io/badge/Blog-k--dense.ai-1a1a1a)](https://www.k-dense.ai/blog)
 
 > 🚀 **Looking for more advanced capabilities?** For end-to-end scientific writing, deep scientific search, advanced image generation and enterprise solutions, visit **[www.k-dense.ai](https://www.k-dense.ai)**


### PR DESCRIPTION
Adds the K-Dense Reddit account ([u/-k-dense-](https://www.reddit.com/user/-k-dense-/)) to the social badge row, directly after the YouTube badge.

This brings the repo in line with `scientific-agent-skills`, `k-dense-byok`, and `drug-discovery-agent-skills`, which already carry the Reddit pill. Uses the `logoColor=white` variant for contrast against the Reddit orange, matching the majority of the existing usages.
